### PR TITLE
Update WemoManager.cpp

### DIFF
--- a/src/WemoManager.cpp
+++ b/src/WemoManager.cpp
@@ -69,7 +69,7 @@ void WemoManager::serverLoop(){
     // Serial.println("----------");
     // Serial.println(request);
     // Serial.println("-----------");
-    if(request.indexOf('M-SEARCH') > 0) {
+    if(request.indexOf("M-SEARCH") > 0) {
         if((request.indexOf("urn:Belkin:device:**") > 0) || (request.indexOf("ssdp:all") > 0) || (request.indexOf("upnp:rootdevice") > 0)) {
           Serial.println("Got UDP Belkin Request..");
 


### PR DESCRIPTION
While compiling on Arduino IDE 2.1.1, a warning is generated: WemoManager.cpp:72:24: warning: character constant too long for its type on Line 72:24:  if(request.indexOf('M-SEARCH') > 0) {

Updating this line to use double quotes instead of single quotes fixed the warning, i.e.:    if(request.indexOf("M-SEARCH") > 0) {